### PR TITLE
[feature] add distributed tracing default feign configuration

### DIFF
--- a/tosan-httpclient-spring-boot-sample/src/main/java/com/tosan/client/http/sample/server/api/config/feign/CustomServerFeignConfig.java
+++ b/tosan-httpclient-spring-boot-sample/src/main/java/com/tosan/client/http/sample/server/api/config/feign/CustomServerFeignConfig.java
@@ -18,6 +18,8 @@ import com.tosan.tools.mask.starter.replace.RegexReplaceHelper;
 import feign.*;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+import feign.micrometer.MicrometerObservationCapability;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -211,6 +213,12 @@ public class CustomServerFeignConfig extends AbstractFeignConfiguration {
     }
 
     @Override
+    @Bean("customServer-micrometerObservationCapability")
+    public MicrometerObservationCapability capability(ObservationRegistry observationRegistry) {
+        return super.capability(observationRegistry);
+    }
+
+    @Override
     @Bean("customServer-feignBuilder")
     public Feign.Builder feignBuilder(@Qualifier("customServer-feignClient") Client feignClient,
                                       @Qualifier("customServer-feignOption") Request.Options options,
@@ -221,9 +229,10 @@ public class CustomServerFeignConfig extends AbstractFeignConfiguration {
                                       @Qualifier("customServer-retryer") Retryer retryer,
                                       @Qualifier("customServer-feignLoggerLevel") Logger.Level logLevel,
                                       @Qualifier("customServer-feignErrorDecoder") CustomErrorDecoder customErrorDecoder,
-                                      @Qualifier("customServer-httpFeignClientLogger") Logger logger) {
+                                      @Qualifier("customServer-httpFeignClientLogger") Logger logger,
+                                      @Qualifier("customServer-micrometerObservationCapability") Capability capability) {
         return super.feignBuilder(feignClient, options, requestInterceptors, feignContract, feignDecoder, feignEncoder,
-                retryer, logLevel, customErrorDecoder, logger);
+                retryer, logLevel, customErrorDecoder, logger, capability);
     }
 
     @Bean

--- a/tosan-httpclient-spring-boot-starter/pom.xml
+++ b/tosan-httpclient-spring-boot-starter/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>feign-hc5</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-micrometer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
             <exclusions>

--- a/tosan-httpclient-spring-boot-starter/src/main/java/com/tosan/client/http/starter/configuration/AbstractFeignConfiguration.java
+++ b/tosan-httpclient-spring-boot-starter/src/main/java/com/tosan/client/http/starter/configuration/AbstractFeignConfiguration.java
@@ -22,6 +22,8 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.form.spring.SpringFormEncoder;
 import feign.hc5.ApacheHttp5Client;
+import feign.micrometer.MicrometerObservationCapability;
+import io.micrometer.observation.ObservationRegistry;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -198,6 +200,10 @@ public abstract class AbstractFeignConfiguration {
                 .isFollowRedirects());
     }
 
+    public MicrometerObservationCapability capability(ObservationRegistry observationRegistry) {
+        return new MicrometerObservationCapability(observationRegistry);
+    }
+
     public Feign.Builder feignBuilder(Client feignClient,
                                       Request.Options options,
                                       List<RequestInterceptor> requestInterceptors,
@@ -207,7 +213,8 @@ public abstract class AbstractFeignConfiguration {
                                       Retryer retryer,
                                       Logger.Level logLevel,
                                       CustomErrorDecoder customErrorDecoder,
-                                      Logger logger) {
+                                      Logger logger,
+                                      Capability capability) {
         return Feign.builder().client(feignClient)
                 .options(options)
                 .encoder(feignEncoder)
@@ -217,7 +224,8 @@ public abstract class AbstractFeignConfiguration {
                 .requestInterceptors(requestInterceptors)
                 .retryer(retryer)
                 .logger(logger)
-                .logLevel(logLevel);
+                .logLevel(logLevel)
+                .addCapability(capability);
     }
 
     protected final <T> T getFeignController(String baseServiceUrl, String controllerPath, Feign.Builder feignBuilder,


### PR DESCRIPTION
A bean of Capability type added to the default feign builder, and the main Capability subtype is considered MicrometerObservationCapability which wraps feign client with micrometer metrics