### PR TITLE
[bug] Load base exception classes in addition to their subtypes

### DIFF
--- a/tosan-httpclient-spring-boot-starter/src/main/java/com/tosan/client/http/starter/impl/feign/CustomErrorDecoder.java
+++ b/tosan-httpclient-spring-boot-starter/src/main/java/com/tosan/client/http/starter/impl/feign/CustomErrorDecoder.java
@@ -130,8 +130,12 @@ public class CustomErrorDecoder implements ErrorDecoder, InitializingBean {
                         "packageList and checkedExceptionClass and uncheckedExceptionClass be filled when " +
                                 "extractType is EXCEPTION_IDENTIFIER_FIELDS or FULL_NAME_REFLECTION");
             }
-            extractAndFillMap(checkedExceptionClass);
-            extractAndFillMap(uncheckedExceptionClass);
+            if (!Modifier.isAbstract(checkedExceptionClass.getModifiers())) {
+                extractAndFillMap(checkedExceptionClass);
+            }
+            if (!Modifier.isAbstract(uncheckedExceptionClass.getModifiers())) {
+                extractAndFillMap(uncheckedExceptionClass);
+            }
             Reflections reflections = new Reflections(scanPackageList.toArray());
             reflections.getSubTypesOf(checkedExceptionClass)
                     .stream().filter(clazz -> !Modifier.isAbstract(clazz.getModifiers())).forEach(this::extractAndFillMap);

--- a/tosan-httpclient-spring-boot-starter/src/main/java/com/tosan/client/http/starter/impl/feign/CustomErrorDecoder.java
+++ b/tosan-httpclient-spring-boot-starter/src/main/java/com/tosan/client/http/starter/impl/feign/CustomErrorDecoder.java
@@ -130,6 +130,8 @@ public class CustomErrorDecoder implements ErrorDecoder, InitializingBean {
                         "packageList and checkedExceptionClass and uncheckedExceptionClass be filled when " +
                                 "extractType is EXCEPTION_IDENTIFIER_FIELDS or FULL_NAME_REFLECTION");
             }
+            extractAndFillMap(checkedExceptionClass);
+            extractAndFillMap(uncheckedExceptionClass);
             Reflections reflections = new Reflections(scanPackageList.toArray());
             reflections.getSubTypesOf(checkedExceptionClass)
                     .stream().filter(clazz -> !Modifier.isAbstract(clazz.getModifiers())).forEach(this::extractAndFillMap);


### PR DESCRIPTION
Previously, only the subtypes of the configured business and runtime exceptions were loaded. This change ensures that the base exception classes themselves are also included during project setup.